### PR TITLE
Toppage footer

### DIFF
--- a/app/assets/stylesheets/_toppage-footer.scss
+++ b/app/assets/stylesheets/_toppage-footer.scss
@@ -84,9 +84,7 @@
     position: relative;
     margin-top:20px;
     bottom: 0;
-    #index-footer-logo {
 
-    }
     .footer-bottom-text{
       font-size: 17px;
       position: absolute;

--- a/app/assets/stylesheets/_toppage-footer.scss
+++ b/app/assets/stylesheets/_toppage-footer.scss
@@ -1,9 +1,4 @@
-.banner{
-  margin-top: auto;
-  width: 100%;
-  height: 70px;
-  background-color: red;
-}
+
 .footer{
   background-color: rgb(34, 34, 34);
   color: rgb(255, 255, 255);
@@ -11,8 +6,8 @@
   padding: 0px 200px 0px 200px;
   display: block;
   box-sizing: border-box;
-  bottom: 0;
-  height: auto;
+  
+  height: 400px;
   &-lists {
     width: 1020px;
     display: flex;
@@ -21,16 +16,16 @@
       padding-left: 0px;
       display: inline-block;
       margin-top: 18px;
-      width: auto;
+
       &-head {
         font-size: 16px;
         font-family: Arial,游ゴシック体,YuGothic,メイリオ,Meiryo,sans-serif;
-        margin: 0;
-        padding: 0;
+        // margin: 0;
+        // padding: 0;
       }
       &-texts{
-        margin: 0;
-        padding: 0;
+        // margin: 0;
+        // padding: 0;
         &-1{
          line-height: 1.4em;
           margin: 16px 0px 0px; 
@@ -59,15 +54,8 @@
     &-full-width{
       margin-top: 18px;
       padding-right: 40px;
-      width: auto;
-      &-head {
-      height: 166px;
-      width: 100%;
-      display: inline-block;
       &-head {
         font-size: 16px;
-        margin: 0;
-        padding: 0;
       }
       &-boxes{
         display: flex;
@@ -91,24 +79,16 @@
        }
     }
    }
-  &-bottom-label {
+  &-bottom-block {
     display: flex;
-    width: 1080px;
-    height: 100px;
-    padding-top: 50px;
     position: relative;
-    margin: 0 auto;
-    &-logo {
-      height: 40px;
-      width: 130px;
-    }
-    &-text{
-      font-size: 17px;
+    margin-top:30px;
+    bottom: 0;
+   
+    .footer-bottom-text{
+      font-size: 17px;
       position: absolute;
-      left: 50%;
-      top: 50%;
-      transform: translateY(-50%) translateX(-50%);
+      left: calc(50% - 54px);
     }
   }
  }
-}

--- a/app/assets/stylesheets/_toppage-footer.scss
+++ b/app/assets/stylesheets/_toppage-footer.scss
@@ -82,13 +82,16 @@
   &-bottom-block {
     display: flex;
     position: relative;
-    margin-top:30px;
+    margin-top:20px;
     bottom: 0;
-   
+    #index-footer-logo {
+
+    }
     .footer-bottom-text{
       font-size: 17px;
       position: absolute;
       left: calc(50% - 54px);
+      top: calc(50% - 17px);
     }
   }
  }

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -48,7 +48,8 @@
 
   .block {
     background-color: #eeeeee;
-    padding: 50px 210px 0 210px;
+    padding: 50px 210px 40px 210px;
+    
     .block_top {
       display: flex;
       position: relative;

--- a/app/views/layouts/_toppage-footer.html.haml
+++ b/app/views/layouts/_toppage-footer.html.haml
@@ -66,8 +66,8 @@
           = link_to "日本","#", class: :"t"
         %li.footer-lists-cell-texts-1
           = link_to "United States","#", class: :"t"
-  .footer-bottom-label
-    .footer-bottom-label-logo
-      =image_tag "fmarket_logo_red.svg"
-    %p.footer-bottom-label-text ©Fmarket,Inc
-= yield
+  .footer-bottom-block
+    .footer-bottom-logo
+      =image_tag "fmarket_logo_white.svg", height:"40px", width:"inherit", id:"index-footer-logo"
+    .footer-bottom-text 
+      ©Fmarket,Inc

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -3,7 +3,7 @@
 .index-main
 
   #slider.slide
-    = image_tag "kabao.jpeg"
+    = image_tag "kabao.jpg"
   .category_tags
     .category 人気のカテゴリー
     .tags
@@ -22,7 +22,7 @@
         = link_to("#", class: 'item_link') do
           .content
             .image
-              = image_tag "kabao.jpeg"
+              = image_tag "kabao.jpg"
               .price
                 #price ¥¥¥¥¥
             .item_name ハリケーン


### PR DESCRIPTION
# what
トップページのフッターのビューの崩れを修正
フッターのロゴの表示を調整
_toppage-footer.haml
_toppage-footer.scss　を修正
トップページが画像ファイルの拡張子によって本番環境で表示できない問題を解決。
posts/index.haml　の拡張子を .jpeg　から　.jpg　に変更

# why
トップページが本番環境で表示できないとアプリの根幹に問題が発生する
