### PR TITLE
create personal_info_page

### DIFF
--- a/app/assets/stylesheets/personal_info.scss
+++ b/app/assets/stylesheets/personal_info.scss
@@ -3,7 +3,7 @@
 .personal_info_wrapper {
   display: flex;
   &__right {
-    padding: 100px 40px;
+    padding: 20px 40px;
   }
   .pi-top {
     height: 50px;

--- a/app/views/posts/personal_info.html.haml
+++ b/app/views/posts/personal_info.html.haml
@@ -1,7 +1,7 @@
 = render  partial: "layouts/toppage-header"
 
 .personal_info_wrapper 
-  =render "sideber"
+  =render "sidebar"
   .personal_info_wrapper__right
     .pi-top 本人情報の登録
     .personal-info-main


### PR DESCRIPTION
# what
本人情報登録ページの作成。
personal_info_haml
personal_info.scss
トップページの部分テンプレート、ヘッダー・フッターと組み合わせ。
_topppage-header.haml
_toppage-footer.haml
マイページの部分テンプレート、サイドバーと組み合わせ。
_sidebar.haml
# why
任意での本人情報、住所の登録のためのページを作るため。

[![Screenshot from Gyazo](https://gyazo.com/d16579e7c7fe4974c86d2f53bb9b5f3c/raw)](https://gyazo.com/d16579e7c7fe4974c86d2f53bb9b5f3c)