### PR TITLE
profile.revise

### DIFF
--- a/app/assets/stylesheets/user.mypage.scss
+++ b/app/assets/stylesheets/user.mypage.scss
@@ -4,7 +4,7 @@
 
 .user-mypage {
   display: flex;
-  margin: 24px auto 0;
+  margin: 0 auto;
   &__main {
     width: 700px;
     margin-left: 40px;

--- a/app/assets/stylesheets/user.profile.scss
+++ b/app/assets/stylesheets/user.profile.scss
@@ -1,7 +1,5 @@
 .user-profile-view {
   display: flex;
-  margin: 24px auto 0;
-  padding: 0 0 40px;
   .user-profile {
     margin: 20px 0 0 40px;
     width: 700px;


### PR DESCRIPTION
What
プロフィール編集画面のサイドバーが中央に寄っているため、padding-leftの要素を排除。

Why
Viewの崩れを修正するため