### PR TITLE
商品一覧機能の絞り込み

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
   require "payjp"
 
   def index
-    @items = Item.all.includes(:images)
+    @items = Item.where.not(status:"2").includes(:images)
   end
 
   def show


### PR DESCRIPTION
# What
商品一覧ページにおいて、売却済の商品を除外

# Why
売却済の商品をユーザーが購入検討しないようにするため。