### PR TITLE
credit-revise

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -15,7 +15,7 @@ class CardsController < ApplicationController
       customer_id: customer.id,   #payjpの顧客id
       card_id: card.id  #payjpのカードid 
     )
-    redirect_to "/posts/mypage"
+    redirect_to "/users/mypage"
   end
 
   def registration
@@ -33,6 +33,7 @@ class CardsController < ApplicationController
   def destroy
     card = Card.where(user_id: current_user.id).first
     card.destroy
+    redirect_to registration_cards_path
   end
 
 end

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -18,7 +18,7 @@
           有効期限
           = exp_month + " / " + exp_year
       .confirm__contents__payment__creditcard__right
-        =link_to "削除する", card_path(current_user.cards.first[:id]), method: :delete, class: :"right-link"
+        =link_to "削除する", "#", method: :delete, class: :"right-link"
     .pay-info
       = link_to "#", class: :"credit-payment-next-page" do
         支払い方法について


### PR DESCRIPTION
What
クレジットカードの削除機能の実装、
クレジットカード登録後のルーティングエラーの解消

Why
クレジットカードを削除するとエラーが出ていたため
クレジットカード登録後、ページの遷移に不備があったため

変更ファイル
cards_controller
views/cards/show.html.haml