### PR TITLE
icon-revise

### DIFF
--- a/app/views/layouts/_footer-icon.html.haml
+++ b/app/views/layouts/_footer-icon.html.haml
@@ -1,5 +1,5 @@
 .footer-log
-  .footer-log__circle
-    = link_to new_item_path, class: :"footer-log__circle__link" do
+  = link_to new_item_path, class: :"footer-log__circle__link" do
+    .footer-log__circle
       %h1.footer-log__circle__link__text 出品
       %span.fas.fa-camera.footer-log__circle__link__icon


### PR DESCRIPTION
What
footerアイコンの修正

Why
アイコンの余白部分をクリックしても出品ページへ飛べなかったため修正